### PR TITLE
Minor compilation fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -Wall -ggdb $(shell sdl-config --cflags)
-LDFLAGS = $(shell sdl-config --libs)
+LDFLAGS = $(shell sdl-config --libs) -lm
 
 OBJECTS = cpu.o main.o main_sdl.o mem.o prefs.o prefs_items.o sid.o
 HEADERS = cpu.h cpu_macros.h cpu_opcodes.h debug.h main.h mem.h prefs.h psid.h sid.h sys.h types.h fixedpointmath.h fixedpointmathcode.h fixedpointmathlut.h


### PR DESCRIPTION
add -lm to linker flags to fix a "undefined reference to symbol 'cos@…@GLIBC_2.2.5'" compile error

Compiles and works on Xubuntu 15.04 now.
